### PR TITLE
Fix default repo detection issue

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -423,8 +423,8 @@ func runCheckoutNew(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	// Step 3: Get base branch - try to detect dynamically
-	baseBranch := getDefaultBranch("")
+	// Step 3: Get base branch - query the specific remote repository
+	baseBranch := getRemoteDefaultBranch(owner, repoName)
 
 	// Step 4: Get base branch SHA
 	fmt.Printf("Fetching base branch '%s' SHA...\n", baseBranch)

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -71,6 +71,42 @@ func getDefaultBranch(workDir string) string {
 	return "main"
 }
 
+// getRemoteDefaultBranch queries a specific remote repository's default branch using GitHub API.
+// This is useful when you need to get the default branch before cloning the repository.
+func getRemoteDefaultBranch(owner, repo string) string {
+	// Try to query the specific repository using GitHub API
+	cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/%s", owner, repo), "--jq", ".default_branch")
+	output, err := cmd.Output()
+	if err == nil {
+		branch := string(output)
+		// Trim whitespace and newlines
+		branch = trimSpace(branch)
+		if branch != "" {
+			return branch
+		}
+	}
+
+	// Fall back to configured checkout_base_branch
+	if baseBranch := config.GetString("checkout_base_branch"); baseBranch != "" {
+		return baseBranch
+	}
+
+	// Final fallback to "main"
+	return "main"
+}
+
+// trimSpace removes leading and trailing whitespace and newlines
+func trimSpace(s string) string {
+	// Remove common whitespace characters
+	result := ""
+	for _, c := range s {
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			result += string(c)
+		}
+	}
+	return result
+}
+
 func init() {
 	// Add subcommands to git command
 	gitCmd.AddCommand(gitStatusCmd)


### PR DESCRIPTION
When creating a new branch with 'work checkout new', the code was incorrectly detecting the default branch of the current directory instead of the target remote repository. This caused it to always default to "main" even when the remote repo used "master".

Changes:
- Add getRemoteDefaultBranch() to query specific repo's default branch via GitHub API
- Update runCheckoutNew() to use getRemoteDefaultBranch(owner, repo) instead of getDefaultBranch("")
- Add trimSpace() helper to properly handle API response formatting

This fix ensures repositories with "master" or other default branches are correctly detected before creating new branches.

Fixes issue where 'master' default branch was not detected.