### PR TITLE
Load repo names on work release tab click

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -32,8 +32,9 @@ Examples:
   work release myrepo --minor      # Increment minor version (v1.0.0 -> v1.1.0)
   work release myrepo --major      # Increment major version (v1.0.0 -> v2.0.0)
 `,
-	Args: cobra.ExactArgs(1),
-	Run:  runRelease,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeGitRepos,
+	Run:               runRelease,
 }
 
 var (


### PR DESCRIPTION
Enable shell tab completion for the `work release` command to load repository names from the default_git_folder. This provides the same autocomplete experience as the checkout command, making it easier for users to select repositories when creating releases.