### PR TITLE
Fix IDE preference not saving in Work Doctor

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -66,6 +66,9 @@ func runSetup(cmd *cobra.Command, args []string) {
 	var ide string
 	var createDir bool
 
+	// Set the current IDE as default
+	ide = currentIDE
+
 	// Create the fancy form
 	form := huh.NewForm(
 		huh.NewGroup(
@@ -108,9 +111,6 @@ func runSetup(cmd *cobra.Command, args []string) {
 				Value(&ide),
 		),
 	)
-
-	// Set the current IDE as default
-	ide = currentIDE
 
 	// Run the form
 	err := form.Run()


### PR DESCRIPTION
The IDE preference default value was being set after the form was created, which prevented the huh library from properly highlighting the currently saved preference in the selection menu.

Moved the 'ide = currentIDE' assignment to before the form creation so the select widget can properly show which option is currently configured.

Fixes issue where running 'work setup' would not show the saved IDE preference as selected.