### PR TITLE
Add webhook-driven auto-sync to work sync

### DIFF
--- a/cmd/launchd.go
+++ b/cmd/launchd.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const launchdLabel = "ai.velvee.work-sync"
+
+func launchdPlistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist"), nil
+}
+
+func launchdLogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".work", "logs", "sync.log"), nil
+}
+
+func launchdUserDomain() string {
+	return "gui/" + strconv.Itoa(os.Getuid())
+}
+
+// launchdLoaded reports whether the LaunchAgent is currently loaded.
+func launchdLoaded() bool {
+	out, _ := exec.Command("launchctl", "list", launchdLabel).Output()
+	return len(out) > 0
+}
+
+// launchdEnsure writes the plist pointing at the current work binary, then
+// loads it if not already loaded. If the plist changed, it reloads. Idempotent.
+func launchdEnsure() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving work binary path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+
+	plistPath, err := launchdPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0755); err != nil {
+		return fmt.Errorf("creating LaunchAgents dir: %w", err)
+	}
+
+	logPath, err := launchdLogPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		return fmt.Errorf("creating log dir: %w", err)
+	}
+
+	plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>%s</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+        <string>sync</string>
+        <string>webhook</string>
+        <string>listen</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>%s</string>
+    <key>StandardErrorPath</key>
+    <string>%s</string>
+</dict>
+</plist>
+`, launchdLabel, exe, logPath, logPath)
+
+	existing, _ := os.ReadFile(plistPath)
+	if string(existing) != plist {
+		if launchdLoaded() {
+			_ = launchdBootout()
+		}
+		if err := os.WriteFile(plistPath, []byte(plist), 0644); err != nil {
+			return fmt.Errorf("writing plist: %w", err)
+		}
+	}
+
+	if !launchdLoaded() {
+		if err := launchdBootstrap(plistPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func launchdBootstrap(plistPath string) error {
+	out, err := exec.Command("launchctl", "bootstrap", launchdUserDomain(), plistPath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("launchctl bootstrap failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func launchdBootout() error {
+	target := launchdUserDomain() + "/" + launchdLabel
+	out, err := exec.Command("launchctl", "bootout", target).CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		// Not-loaded is not an error for our purposes.
+		if strings.Contains(msg, "Could not find") || strings.Contains(msg, "No such") {
+			return nil
+		}
+		return fmt.Errorf("launchctl bootout failed: %w: %s", err, strings.TrimSpace(msg))
+	}
+	return nil
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -384,6 +384,23 @@ func runDoctor(cmd *cobra.Command, args []string) {
 			orgAccessResult.status = "⚠ Cannot access configured orgs (may need valid org names)"
 		}
 		results <- orgAccessResult
+
+		// Webhook scope check — needed for 'work sync <repo>' to create
+		// GitHub webhooks. Either `repo` or `admin:repo_hook` is enough.
+		scopeResult := checkResult{name: "gh webhook scope", order: 2, critical: false}
+		scopes := parseGhScopes(outputStr)
+		if len(scopes) == 0 {
+			scopeResult.status = "⚠ Could not read token scopes"
+		} else if ghHasWebhookScope(scopes) {
+			scopeResult.status = "✓ (token has repo or admin:repo_hook)"
+		} else {
+			scopeResult.status = "⚠ MISSING"
+			scopeResult.details = []string{
+				"Needed for 'work sync <repo>' to install GitHub webhooks.",
+				"Run: gh auth refresh -s admin:repo_hook",
+			}
+		}
+		results <- scopeResult
 	}()
 
 	// Close results channel when all checks complete
@@ -434,6 +451,39 @@ func runDoctor(cmd *cobra.Command, args []string) {
 		fmt.Println("Fix the issues above, then run 'work doctor' again")
 	}
 	fmt.Println("========================")
+}
+
+// parseGhScopes extracts OAuth scopes from `gh auth status` output, which
+// contains a line like: "  - Token scopes: 'repo', 'read:org', ..."
+func parseGhScopes(ghAuthStatusOutput string) []string {
+	for _, line := range strings.Split(ghAuthStatusOutput, "\n") {
+		line = strings.TrimSpace(line)
+		raw, ok := strings.CutPrefix(line, "- Token scopes:")
+		if !ok {
+			continue
+		}
+		var scopes []string
+		for _, s := range strings.Split(raw, ",") {
+			s = strings.TrimSpace(s)
+			s = strings.Trim(s, "'\"")
+			if s != "" {
+				scopes = append(scopes, s)
+			}
+		}
+		return scopes
+	}
+	return nil
+}
+
+// ghHasWebhookScope returns true if the token has a scope sufficient to
+// create a repo webhook. `repo` (classic PAT) or `admin:repo_hook` both work.
+func ghHasWebhookScope(scopes []string) bool {
+	for _, s := range scopes {
+		if s == "repo" || s == "admin:repo_hook" || s == "write:repo_hook" {
+			return true
+		}
+	}
+	return false
 }
 
 func init() {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -13,19 +13,29 @@ import (
 	"github.com/velvee-ai/ai-workflow/pkg/services"
 )
 
+var (
+	syncOff  bool
+	syncOnce bool
+)
+
 var syncCmd = &cobra.Command{
 	Use:   "sync [repo]",
-	Short: "Sync default branch across repositories",
-	Long: `Sync the default branch (main/master) across all repositories or a specific repository.
+	Short: "Sync default branch and (for a single repo) enable auto-sync",
+	Long: `Sync the default branch (main/master) across your repositories.
 
-This command helps keep your default branches up-to-date by:
-  - Switching to the default branch in the main worktree
-  - Pulling the latest changes with rebase
-  - Reporting any errors or conflicts
+Without arguments: pull --rebase on every discovered repo (one-shot).
+
+With a repo argument: full auto-sync setup (idempotent) — creates a
+smee.io channel if needed, installs a GitHub push webhook on the repo,
+starts the launchd listener daemon, and then pulls --rebase once.
+After the first run, further pushes to the default branch sync
+automatically in the background.
 
 Examples:
-  work sync              # Sync all repositories
-  work sync ai-workflow  # Sync specific repository`,
+  work sync                     # One-shot sync of every repo
+  work sync ai-workflow         # Full auto-sync setup + pull for one repo
+  work sync ai-workflow --once  # Skip setup, just pull once
+  work sync ai-workflow --off   # Remove the GitHub webhook for this repo`,
 	ValidArgsFunction: completeReposForSync,
 	Run:               runSync,
 }
@@ -40,6 +50,68 @@ type SyncResult struct {
 }
 
 func runSync(cmd *cobra.Command, args []string) {
+	if syncOff {
+		runSyncDisable(cmd, args)
+		return
+	}
+	if len(args) > 0 && !syncOnce {
+		runSyncEnable(cmd, args[0])
+		return
+	}
+	runSyncPullOnly(cmd, args)
+}
+
+// runSyncEnable is the "do it all" path for a single repo: ensure smee
+// channel + GitHub webhook + launchd daemon, then pull once.
+func runSyncEnable(cmd *cobra.Command, repoName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	gitFolder := resolvedGitFolder()
+	if gitFolder == "" {
+		fmt.Fprintln(os.Stderr, "Error: default_git_folder is not configured or does not exist")
+		fmt.Fprintln(os.Stderr, "Run: work setup")
+		os.Exit(1)
+	}
+
+	localPath, err := enableAutoSync(ctx, gitFolder, repoName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	result := syncRepository(ctx, localPath)
+	if result.Success {
+		fmt.Printf("✓ %s (%s): %s\n", result.RepoName, result.DefaultBranch, result.Message)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "✗ %s: %s\n", result.RepoName, result.Error.Error())
+	os.Exit(1)
+}
+
+// runSyncDisable removes the webhook for a single repo.
+func runSyncDisable(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Error: --off requires a repo name")
+		fmt.Fprintln(os.Stderr, "Example: work sync ai-workflow --off")
+		os.Exit(1)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	gitFolder := resolvedGitFolder()
+	if gitFolder == "" {
+		fmt.Fprintln(os.Stderr, "Error: default_git_folder is not configured or does not exist")
+		os.Exit(1)
+	}
+	if err := disableAutoSync(ctx, gitFolder, args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runSyncPullOnly is the classic sync-all (and `--once <repo>`) path.
+func runSyncPullOnly(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -250,5 +322,7 @@ func completeReposForSync(cmd *cobra.Command, args []string, toComplete string) 
 }
 
 func init() {
+	syncCmd.Flags().BoolVar(&syncOff, "off", false, "Remove the GitHub webhook for this repo (requires a repo name)")
+	syncCmd.Flags().BoolVar(&syncOnce, "once", false, "Skip webhook and daemon setup; just pull --rebase once")
 	rootCmd.AddCommand(syncCmd)
 }

--- a/cmd/sync_enable.go
+++ b/cmd/sync_enable.go
@@ -1,0 +1,239 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/velvee-ai/ai-workflow/pkg/config"
+)
+
+// enableAutoSync performs the full idempotent setup for a single repo:
+// resolves owner/repo from the local git remote, ensures a smee channel
+// URL is saved, installs the GitHub webhook if not already present, and
+// ensures the launchd listener daemon is loaded.
+//
+// Each step prints a line only when it actually performs work. In steady
+// state (webhook installed, daemon running) this function is silent.
+func enableAutoSync(ctx context.Context, gitFolder, repoName string) (localPath string, err error) {
+	localPath = filepath.Join(gitFolder, repoName)
+	mainPath := filepath.Join(localPath, "main")
+	if _, err := os.Stat(filepath.Join(mainPath, ".git")); err != nil {
+		return "", fmt.Errorf("no git repo at %s", mainPath)
+	}
+
+	slug, err := resolveRepoSlug(ctx, mainPath)
+	if err != nil {
+		return "", err
+	}
+
+	smeeURL, createdChannel, err := ensureSmeeChannel()
+	if err != nil {
+		return "", err
+	}
+	if createdChannel {
+		fmt.Printf("✓ Created smee channel: %s\n", smeeURL)
+	}
+
+	installed, err := ensureGitHubHook(ctx, slug, smeeURL)
+	if err != nil {
+		return "", err
+	}
+	if installed {
+		fmt.Printf("✓ Installed webhook on %s\n", slug)
+	}
+
+	wasLoaded := launchdLoaded()
+	if err := launchdEnsure(); err != nil {
+		return "", fmt.Errorf("starting sync daemon: %w", err)
+	}
+	if !wasLoaded {
+		fmt.Printf("✓ Started sync daemon (launchd agent %s)\n", launchdLabel)
+	}
+
+	return localPath, nil
+}
+
+// disableAutoSync removes the webhook (pointing to our smee channel) from
+// the GitHub repo. It does not stop the launchd daemon — other repos may
+// still be using it.
+func disableAutoSync(ctx context.Context, gitFolder, repoName string) error {
+	mainPath := filepath.Join(gitFolder, repoName, "main")
+	if _, err := os.Stat(filepath.Join(mainPath, ".git")); err != nil {
+		return fmt.Errorf("no git repo at %s", mainPath)
+	}
+
+	slug, err := resolveRepoSlug(ctx, mainPath)
+	if err != nil {
+		return err
+	}
+
+	smeeURL := config.GetString("smee_channel_url")
+	if smeeURL == "" {
+		fmt.Println("No smee channel configured; nothing to remove.")
+		return nil
+	}
+
+	hooks, err := listGitHubHooks(ctx, slug)
+	if err != nil {
+		return err
+	}
+
+	removed := 0
+	for _, h := range hooks {
+		if h.Config.URL == smeeURL {
+			if err := deleteGitHubHook(ctx, slug, h.ID); err != nil {
+				return err
+			}
+			removed++
+		}
+	}
+	if removed == 0 {
+		fmt.Printf("No matching webhook on %s.\n", slug)
+	} else {
+		fmt.Printf("✓ Removed %d webhook(s) from %s\n", removed, slug)
+	}
+	return nil
+}
+
+// resolveRepoSlug returns "owner/repo" from the git remote of the repo at
+// path. Uses `gh repo view` which reads the origin remote.
+func resolveRepoSlug(ctx context.Context, path string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+	cmd.Dir = path
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh repo view failed in %s: %w (%s)", path, err, strings.TrimSpace(stderr.String()))
+	}
+	slug := strings.TrimSpace(string(out))
+	if slug == "" {
+		return "", fmt.Errorf("gh repo view returned empty slug for %s", path)
+	}
+	return slug, nil
+}
+
+// ensureSmeeChannel returns the configured channel URL, creating and
+// persisting a new one if none is set. `created` is true iff this call
+// generated a new channel.
+func ensureSmeeChannel() (url string, created bool, err error) {
+	url = config.GetString("smee_channel_url")
+	if url != "" {
+		return url, false, nil
+	}
+	url, err = createSmeeChannel()
+	if err != nil {
+		return "", false, err
+	}
+	if err := config.Set("smee_channel_url", url); err != nil {
+		return "", false, fmt.Errorf("saving smee_channel_url: %w", err)
+	}
+	return url, true, nil
+}
+
+// createSmeeChannel hits smee.io/new and returns the redirect Location.
+func createSmeeChannel() (string, error) {
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get("https://smee.io/new")
+	if err != nil {
+		return "", fmt.Errorf("contacting smee.io: %w", err)
+	}
+	defer resp.Body.Close()
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		return "", fmt.Errorf("smee.io returned HTTP %d with no Location header", resp.StatusCode)
+	}
+	return loc, nil
+}
+
+type ghHook struct {
+	ID     int `json:"id"`
+	Config struct {
+		URL string `json:"url"`
+	} `json:"config"`
+}
+
+func listGitHubHooks(ctx context.Context, slug string) ([]ghHook, error) {
+	cmd := exec.CommandContext(ctx, "gh", "api", "--paginate", "/repos/"+slug+"/hooks")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("listing webhooks on %s: %w (%s)", slug, err, strings.TrimSpace(stderr.String()))
+	}
+	var hooks []ghHook
+	if err := json.Unmarshal(out, &hooks); err != nil {
+		return nil, fmt.Errorf("parsing webhook list for %s: %w", slug, err)
+	}
+	return hooks, nil
+}
+
+// ensureGitHubHook creates a push webhook pointing to smeeURL if one does
+// not already exist. Returns true iff it created a new hook.
+func ensureGitHubHook(ctx context.Context, slug, smeeURL string) (bool, error) {
+	hooks, err := listGitHubHooks(ctx, slug)
+	if err != nil {
+		return false, err
+	}
+	for _, h := range hooks {
+		if h.Config.URL == smeeURL {
+			return false, nil
+		}
+	}
+	if err := createGitHubHook(ctx, slug, smeeURL); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func createGitHubHook(ctx context.Context, slug, smeeURL string) error {
+	payload := map[string]interface{}{
+		"name":   "web",
+		"active": true,
+		"events": []string{"push"},
+		"config": map[string]string{
+			"url":          smeeURL,
+			"content_type": "json",
+			"insecure_ssl": "0",
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "gh", "api", "-X", "POST", "/repos/"+slug+"/hooks", "--input", "-")
+	cmd.Stdin = bytes.NewReader(body)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if strings.Contains(msg, "admin:repo_hook") || strings.Contains(msg, "Resource not accessible") {
+			return fmt.Errorf("creating webhook on %s: %w\n%s\nRun 'work doctor' to check your gh token scopes", slug, err, msg)
+		}
+		return fmt.Errorf("creating webhook on %s: %w (%s)", slug, err, msg)
+	}
+	return nil
+}
+
+func deleteGitHubHook(ctx context.Context, slug string, id int) error {
+	cmd := exec.CommandContext(ctx, "gh", "api", "-X", "DELETE", fmt.Sprintf("/repos/%s/hooks/%d", slug, id))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("deleting webhook %d on %s: %w (%s)", id, slug, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}

--- a/cmd/sync_webhook.go
+++ b/cmd/sync_webhook.go
@@ -1,0 +1,358 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/velvee-ai/ai-workflow/pkg/config"
+)
+
+var syncWebhookCmd = &cobra.Command{
+	Use:   "webhook",
+	Short: "GitHub webhook-driven sync via smee.io",
+	Long: `Receive GitHub push webhooks through a smee.io channel and sync the
+matching local repo's default branch automatically.
+
+Subcommands:
+  work sync webhook setup   - Create a smee channel and save the URL
+  work sync webhook listen  - Run the listener daemon`,
+}
+
+var syncWebhookSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Create a smee.io channel for receiving webhooks",
+	Long: `Create a new smee.io channel and save it to the config file.
+
+After running this, add the printed URL as a webhook on each GitHub repo
+you want to auto-sync:
+  Settings > Webhooks > Add webhook
+    Payload URL:  <printed URL>
+    Content type: application/json
+    Events:       Just the push event
+
+Then run 'work sync webhook listen' to start receiving and syncing.
+
+Security note: the smee channel URL is the only secret — anyone who
+knows it can deliver events. Do not share it.`,
+	Run: runSyncWebhookSetup,
+}
+
+var syncWebhookListenCmd = &cobra.Command{
+	Use:   "listen",
+	Short: "Listen for webhooks and sync matching repos",
+	Long: `Long-running listener: connects to the configured smee channel,
+receives GitHub push events, and syncs the matching local repo's default
+branch by running the same logic as 'work sync <repo>'.
+
+Only push events to a repo's default branch trigger a sync. Pushes to
+feature branches, pull_request events, pings, etc. are ignored.
+
+Repos are matched by name: a push to owner/foo syncs
+<default_git_folder>/foo/main if it exists locally.
+
+Reconnects on disconnect with exponential backoff. Ctrl+C to stop.`,
+	Run: runSyncWebhookListen,
+}
+
+func runSyncWebhookSetup(cmd *cobra.Command, args []string) {
+	existing := config.GetString("smee_channel_url")
+	if existing != "" {
+		fmt.Printf("Existing smee channel: %s\n", existing)
+		fmt.Print("Replace with a new channel? [y/N] ")
+		var response string
+		fmt.Scanln(&response)
+		response = strings.ToLower(strings.TrimSpace(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Keeping existing channel.")
+			return
+		}
+	}
+
+	channelURL, err := createSmeeChannel()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := config.Set("smee_channel_url", channelURL); err != nil {
+		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Smee channel created: %s\n", channelURL)
+	fmt.Println()
+	fmt.Println("Add this as a webhook on each repo you want auto-synced:")
+	fmt.Println("  1. GitHub repo > Settings > Webhooks > Add webhook")
+	fmt.Printf("  2. Payload URL:  %s\n", channelURL)
+	fmt.Println("  3. Content type: application/json")
+	fmt.Println("  4. Events:       Just the push event")
+	fmt.Println()
+	fmt.Println("Then run:")
+	fmt.Println("  work sync webhook listen")
+}
+
+func runSyncWebhookListen(cmd *cobra.Command, args []string) {
+	channelURL := config.GetString("smee_channel_url")
+	if channelURL == "" {
+		fmt.Fprintln(os.Stderr, "Error: smee_channel_url is not configured")
+		fmt.Fprintln(os.Stderr, "Run: work sync webhook setup")
+		os.Exit(1)
+	}
+
+	gitFolder := resolvedGitFolder()
+	if gitFolder == "" {
+		fmt.Fprintln(os.Stderr, "Error: default_git_folder is not configured or does not exist")
+		fmt.Fprintln(os.Stderr, "Run: work config set default_git_folder <path>")
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		fmt.Fprintln(os.Stderr, "\nShutting down.")
+		cancel()
+	}()
+
+	fmt.Printf("Listening on %s\n", channelURL)
+	fmt.Printf("Git folder:  %s\n", gitFolder)
+	fmt.Println("Ctrl+C to stop.")
+
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+	var lastCatchup time.Time
+
+	for {
+		// Smee has no persistence: any webhook that arrived while we were
+		// offline (reboot, sleep, network loss) is gone. Run a catch-up
+		// pull before each connection attempt so local repos don't drift.
+		// Rate-limit to at most once per minute to avoid hammering during
+		// a reconnect storm.
+		if time.Since(lastCatchup) > time.Minute {
+			runCatchup(ctx, gitFolder)
+			lastCatchup = time.Now()
+		}
+
+		err := runSmeeLoop(ctx, channelURL, gitFolder)
+		if err == nil || errors.Is(err, context.Canceled) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Connection lost: %v (retry in %s)\n", err, backoff)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}
+
+// runCatchup pulls --rebase every discovered repo once. Used on daemon
+// startup and after reconnects to cover events missed while offline.
+func runCatchup(ctx context.Context, gitFolder string) {
+	entries, err := os.ReadDir(gitFolder)
+	if err != nil {
+		return
+	}
+	catchupCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		repoPath := filepath.Join(gitFolder, entry.Name())
+		if _, err := os.Stat(filepath.Join(repoPath, "main", ".git")); err != nil {
+			continue
+		}
+		result := syncRepository(catchupCtx, repoPath)
+		if result.Success && result.Message != "Already up to date" {
+			fmt.Printf("↻ catchup %s (%s): %s\n", result.RepoName, result.DefaultBranch, result.Message)
+		} else if !result.Success {
+			fmt.Fprintf(os.Stderr, "✗ catchup %s: %s\n", result.RepoName, result.Error.Error())
+		}
+	}
+}
+
+// runSmeeLoop opens one SSE connection to the smee channel and dispatches
+// events until the connection closes or the context is cancelled.
+func runSmeeLoop(ctx context.Context, channelURL, gitFolder string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, channelURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("User-Agent", "work-sync-webhook/1")
+
+	// No client-level timeout — this connection is intentionally long-lived.
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("smee returned HTTP %d", resp.StatusCode)
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	var dataBuf strings.Builder
+	var eventName string
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return io.ErrUnexpectedEOF
+			}
+			return err
+		}
+		line = strings.TrimRight(line, "\r\n")
+
+		if line == "" {
+			if dataBuf.Len() > 0 {
+				handleSmeeEvent(ctx, eventName, dataBuf.String(), gitFolder)
+			}
+			dataBuf.Reset()
+			eventName = ""
+			continue
+		}
+
+		// SSE comment / keepalive
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		field, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		value = strings.TrimPrefix(value, " ")
+
+		switch field {
+		case "event":
+			eventName = value
+		case "data":
+			if dataBuf.Len() > 0 {
+				dataBuf.WriteByte('\n')
+			}
+			dataBuf.WriteString(value)
+		}
+	}
+}
+
+// handleSmeeEvent parses one smee envelope and, if it's a push to a repo's
+// default branch that exists locally, syncs it.
+func handleSmeeEvent(ctx context.Context, eventName, data, gitFolder string) {
+	// smee-specific events we don't care about (ready, ping, etc.)
+	if eventName != "" && eventName != "message" {
+		return
+	}
+
+	// Smee wraps the webhook in a JSON object with headers at the top level
+	// (lowercased) and the parsed body under "body".
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(data), &env); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse smee envelope: %v\n", err)
+		return
+	}
+
+	var ghEvent string
+	if raw, ok := env["x-github-event"]; ok {
+		_ = json.Unmarshal(raw, &ghEvent)
+	}
+	if ghEvent != "push" {
+		return
+	}
+
+	rawBody, ok := env["body"]
+	if !ok {
+		return
+	}
+
+	var body struct {
+		Ref        string `json:"ref"`
+		Deleted    bool   `json:"deleted"`
+		Repository struct {
+			Name          string `json:"name"`
+			FullName      string `json:"full_name"`
+			DefaultBranch string `json:"default_branch"`
+		} `json:"repository"`
+	}
+	if err := json.Unmarshal(rawBody, &body); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse push body: %v\n", err)
+		return
+	}
+
+	if body.Deleted {
+		return
+	}
+	if body.Repository.Name == "" || body.Repository.DefaultBranch == "" {
+		return
+	}
+	if body.Ref != "refs/heads/"+body.Repository.DefaultBranch {
+		// Push to a non-default branch — ignore.
+		return
+	}
+
+	repoPath := filepath.Join(gitFolder, body.Repository.Name)
+	if _, err := os.Stat(filepath.Join(repoPath, "main", ".git")); err != nil {
+		fmt.Printf("↷ %s: no local repo at %s, skipping\n", body.Repository.FullName, repoPath)
+		return
+	}
+
+	fmt.Printf("↻ %s: push to %s\n", body.Repository.FullName, body.Repository.DefaultBranch)
+	syncCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	result := syncRepository(syncCtx, repoPath)
+	if result.Success {
+		fmt.Printf("✓ %s (%s): %s\n", result.RepoName, result.DefaultBranch, result.Message)
+	} else {
+		fmt.Fprintf(os.Stderr, "✗ %s: %s\n", result.RepoName, result.Error.Error())
+	}
+}
+
+// resolvedGitFolder returns the expanded default_git_folder if it exists.
+func resolvedGitFolder() string {
+	gitFolder := config.GetString("default_git_folder")
+	if gitFolder == "" {
+		return ""
+	}
+	if strings.HasPrefix(gitFolder, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		gitFolder = filepath.Join(home, gitFolder[2:])
+	}
+	if _, err := os.Stat(gitFolder); err != nil {
+		return ""
+	}
+	return gitFolder
+}
+
+func init() {
+	syncWebhookCmd.AddCommand(syncWebhookSetupCmd)
+	syncWebhookCmd.AddCommand(syncWebhookListenCmd)
+	syncCmd.AddCommand(syncWebhookCmd)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	PreferredIDE       string   `mapstructure:"preferred_ide" json:"preferred_ide"`
 	CheckoutBaseBranch string   `mapstructure:"checkout_base_branch" json:"checkout_base_branch"`
 	CacheTTL           string   `mapstructure:"cache_ttl" json:"cache_ttl"` // Duration string like "5m"
+	SmeeChannelURL     string   `mapstructure:"smee_channel_url" json:"smee_channel_url"`
 }
 
 var (
@@ -118,6 +119,7 @@ func Save(cfg *Config) error {
 	viper.Set("preferred_ide", cfg.PreferredIDE)
 	viper.Set("checkout_base_branch", cfg.CheckoutBaseBranch)
 	viper.Set("cache_ttl", cfg.CacheTTL)
+	viper.Set("smee_channel_url", cfg.SmeeChannelURL)
 
 	return viper.WriteConfig()
 }


### PR DESCRIPTION
## Summary

- \`work sync <repo>\` is now an idempotent end-to-end setup: creates a smee.io channel if needed, installs a GitHub push webhook on the repo via \`gh api\`, loads a launchd LaunchAgent that runs the listener, and pulls \`--rebase\` once. After the first run, every push to the default branch triggers an automatic pull in the background.
- Listener survives reboots (RunAtLoad), crashes (KeepAlive), and sleep/wake via reconnect with exponential backoff. Smee has no persistence, so before each (re)connect the daemon runs a catch-up pull on every tracked repo, rate-limited to once/minute.
- \`work doctor\` now checks for \`repo\` or \`admin:repo_hook\` scope.
- \`work sync <repo> --off\` removes the webhook; \`--once\` skips setup and just pulls.

## Test plan

- [x] \`go build\`, \`go vet\`, \`go test ./...\` all clean
- [ ] \`work sync <test-repo>\` installs webhook on GitHub and starts the launchd agent
- [ ] \`launchctl list ai.velvee.work-sync\` shows the agent running
- [ ] Push to default branch → \`tail -f ~/.work/logs/sync.log\` shows the sync
- [ ] Close lid >1min, open, push → catch-up + event-driven sync both fire
- [ ] \`work sync <repo> --off\` removes the webhook cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)